### PR TITLE
Added compatibility with Semver

### DIFF
--- a/platformio_dependabot/__main__.py
+++ b/platformio_dependabot/__main__.py
@@ -23,7 +23,7 @@ def main():
     packages = get_outdated_libraries(config.project_path)
 
     for package in packages:
-        logger.info(f"Updating '{package.name}' to {package.latestVersion} ...")
+        logger.info(f"Updating '{package.name}@{package.requirements}' from {package.currentVersion} to {package.latestVersion} ...")
 
         branch_name = f"platformio_dependabot/{package.name}/{package.latestVersion}"
         branch_name = branch_name.replace(" ", "_")
@@ -34,10 +34,12 @@ def main():
             logger.warning("Pull Request already existing, will do nothing.")
             continue
 
+        if update_ini_file(config.platformio_ini, package) == False:
+            logger.warning("No matching string to replace, will do nothing.")
+            continue
+
         repo = Repo(Path("/github/workspace"))
         create_branch(repo, branch_name)
-
-        update_ini_file(config.platformio_ini, package)
 
         add_file_commit_and_push(repo, branch_name, config.platformio_ini, package)
         checkout_base_branch(repo, github_repo)

--- a/platformio_dependabot/platformio.py
+++ b/platformio_dependabot/platformio.py
@@ -44,7 +44,7 @@ def update_ini_file(iniFile: Path, package: PackageDefinition) -> bool:
     data = ""
 
     matches = re.search(r"^\s*([\^~<>=]*)\s*(.+)\s*$", package.requirements)
-    operator = matches.group(1);
+    operator = matches.group(1)
     requiredVersion = matches.group(2)
 
     eName = re.escape(f"{package.name}")

--- a/platformio_dependabot/platformio.py
+++ b/platformio_dependabot/platformio.py
@@ -43,7 +43,7 @@ def update_ini_file(iniFile: Path, package: PackageDefinition) -> bool:
     updated = False
     data = ""
 
-    matches = re.search(r"^\s*([\^~<>=]*)\s*(.+)$", package.requirements)
+    matches = re.search(r"^\s*([\^~<>=]*)\s*(.+)\s*$", package.requirements)
     operator = matches.group(1);
     requiredVersion = matches.group(2)
 
@@ -53,7 +53,7 @@ def update_ini_file(iniFile: Path, package: PackageDefinition) -> bool:
 
     with open(iniFile, "rt") as f:
         data = f.read()
-        matches = re.findall(rf"({eName}(\s*)@(\s*){eOperator}(\s*)?{eRequiredVersion})", data)
+        matches = re.findall(rf"({eName}(\s*)@(\s*){eOperator}(\s*){eRequiredVersion})", data)
 
         for matched, space1, space2, space3 in matches:
             updated = True


### PR DESCRIPTION
This PR solves issue #4
It works correctly with version forms:
```
bblanchon/ArduinoJson@^6.0.0
bblanchon/ArduinoJson@>6.0.0
bblanchon/ArduinoJson@>=6.0.0
bblanchon/ArduinoJson@<6.0.0
bblanchon/ArduinoJson@<=6.0.0
bblanchon/ArduinoJson@~6.0.0
```

With spaces or without spaces:
```
bblanchon/ArduinoJson @ ^6.0.0
bblanchon/ArduinoJson@^6.0.0
bblanchon/ArduinoJson @ 6.0.0
bblanchon/ArduinoJson@6.0.0
```

But not compatible with complex conditions.
If no changes have been made to the file, then the PR is not created.