### PR TITLE
Configure bot credentials

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh -l
 
 git config --global --add safe.directory /github/workspace
+git config --global user.name 'github-actions[bot]'
+git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
 export PYTHONPATH=$PYTHONPATH:/app
 python3 -m platformio_dependabot


### PR DESCRIPTION
This adds github-actions bot credentials to the action. Just makes the commits a bit tidier, rather than just a generic root. Emaple: https://github.com/oleksiikutuzov/esp32c3-homekit-led-strip-controller/pull/16/commits/7231a57b7349a9d0cb9e88f3e2f3c2745c12fbe8